### PR TITLE
update rule id 960012

### DIFF
--- a/base_rules/modsecurity_crs_20_protocol_violations.conf
+++ b/base_rules/modsecurity_crs_20_protocol_violations.conf
@@ -293,14 +293,15 @@ SecRule REQUEST_METHOD "^(?:GET|HEAD)$" \
 # header is also present.
 #
 # -=[ References ]=-
-# http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5
+# http://www.w3.org/Protocols/HTTP/1.0/spec.html#POST
+# http://www.w3.org/Protocols/HTTP/1.0/spec.html#Content-Length
 # 
 SecRule REQUEST_METHOD "^POST$" \
   "msg:'POST request missing Content-Length Header.',\
   severity:'4',\
   id:'960012',\
   ver:'OWASP_CRS/2.2.9',\
-  rev:'1',\
+  rev:'2',\
   maturity:'9',\
   accuracy:'9',\
   phase:1,\
@@ -310,10 +311,12 @@ SecRule REQUEST_METHOD "^POST$" \
   tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
   tag:'CAPEC-272',\
   chain"
+  	SecRule REQUEST_PROTOCOL "^HTTP/1\.0$" \
+  	  "chain"
         SecRule &REQUEST_HEADERS:Content-Length "@eq 0" \
           "t:none,\
           setvar:'tx.msg=%{rule.msg}',\
-          setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
+          setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
           setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}'"
 
 


### PR DESCRIPTION
- rule id 960012 updated to actual HTTP protocol specifications (only valid for HTTP/1.0)
- a similary rule should be added to modsecurity_crs_21_protocol_anomalies.conf with a check for request protocol HTTP/1.1 and if a Transfer-Encoding header is missing
